### PR TITLE
Add rescued data column to schema

### DIFF
--- a/get-schema.py
+++ b/get-schema.py
@@ -118,6 +118,14 @@ df = df.drop("_corrupt_record")
 schema_json_str = df.schema.json()
 schema_json = json.loads(schema_json_str)
 
+# Always include a placeholder column for storing rescued records
+schema_json.get("fields", []).append({
+    "metadata": {},
+    "name": "_rescued_data",
+    "nullable": True,
+    "type": "string",
+})
+
 result = {}
 result["readStreamOptions"] = {"cloudFiles.format": args.type}
 if args.type == "csv":


### PR DESCRIPTION
## Summary
- update `get-schema.py` to always append a `_rescued_data` field

## Testing
- `python3 -m py_compile get-schema.py`


------
https://chatgpt.com/codex/tasks/task_e_686c21916eb48329be5cb2cbbd13952b