### PR TITLE
Add profile argument to empty-s3-bucket

### DIFF
--- a/empty-s3-bucket.sh
+++ b/empty-s3-bucket.sh
@@ -2,22 +2,24 @@
 
 set -euo pipefail
 
-if [[ $# -ne 1 ]]; then
-    echo "Usage: $0 <bucket-name>" >&2
+if [[ $# -ne 2 ]]; then
+    echo "Usage: $0 <aws-profile> <bucket-name>" >&2
     exit 1
 fi
 
-BUCKET="$1"
+PROFILE="$1"
+BUCKET="$2"
+AWS_CLI=(aws --profile "$PROFILE")
 
 # List all object versions and delete markers and remove them permanently.
 # Run up to 10 deletions in parallel so the machine isn't overwhelmed.
 MAX_JOBS=10
 current_jobs=0
 
-aws s3api list-object-versions --bucket "$BUCKET" --output json \
+"${AWS_CLI[@]}" s3api list-object-versions --bucket "$BUCKET" --output json \
     | jq -r '.Versions[]?, .DeleteMarkers[]? | [.Key, .VersionId] | @tsv' \
     | while IFS=$'\t' read -r KEY VERSION_ID; do
-        aws s3api delete-object --bucket "$BUCKET" --key "$KEY" --version-id "$VERSION_ID" &
+        "${AWS_CLI[@]}" s3api delete-object --bucket "$BUCKET" --key "$KEY" --version-id "$VERSION_ID" &
         ((current_jobs++))
         if (( current_jobs >= MAX_JOBS )); then
             wait -n


### PR DESCRIPTION
## Summary
- allow specifying an AWS CLI profile when emptying a bucket

## Testing
- `bash -n empty-s3-bucket.sh`

------
https://chatgpt.com/codex/tasks/task_e_687680a461f48329aec534c78e5b0a4a