### PR TITLE
Improve output formatting for total space script

### DIFF
--- a/total_space_all_versions.sh
+++ b/total_space_all_versions.sh
@@ -16,7 +16,15 @@ ALL_SIZE=$("${AWS_CLI[@]}" s3api list-object-versions --bucket "$BUCKET" --prefi
 CURRENT_SIZE=$("${AWS_CLI[@]}" s3api list-objects-v2 --bucket "$BUCKET" --prefix "$PREFIX" --output json | jq '([.Contents[].Size] | add) // 0')
 PREVIOUS_SIZE=$((ALL_SIZE - CURRENT_SIZE))
 
-printf "Current versions total size (bytes): %s\n" "$CURRENT_SIZE"
-printf "Previous versions total size (bytes): %s\n" "$PREVIOUS_SIZE"
-printf "All versions total size (bytes): %s\n" "$ALL_SIZE"
+to_human() {
+    numfmt --to=iec --suffix=B "$1"
+}
+
+CURRENT_HUMAN=$(to_human "$CURRENT_SIZE")
+PREVIOUS_HUMAN=$(to_human "$PREVIOUS_SIZE")
+ALL_HUMAN=$(to_human "$ALL_SIZE")
+
+printf "Current versions total size: %s (%s bytes)\n" "$CURRENT_HUMAN" "$CURRENT_SIZE"
+printf "Previous versions total size: %s (%s bytes)\n" "$PREVIOUS_HUMAN" "$PREVIOUS_SIZE"
+printf "All versions total size: %s (%s bytes)\n" "$ALL_HUMAN" "$ALL_SIZE"
 


### PR DESCRIPTION
## Summary
- show S3 sizes in a human-readable format
- print both human-readable and raw byte sizes

## Testing
- `numfmt --to=iec --suffix=B 123456789`
- `numfmt --to=iec --suffix=B 1099511627776`


------
https://chatgpt.com/codex/tasks/task_e_6878ff9e5c3c8329a92103829eed72c4